### PR TITLE
Remove TakClient singleton, Add MakeTeamMarker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ide configuration
+.idea
+
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -31,8 +31,6 @@ type TakClient struct {
 	cancel   context.CancelFunc
 }
 
-var c *TakClient
-
 func NewTakClient(ctx context.Context, config ClientConfig) (*TakClient, error) {
 
 	if config.Host == "" {
@@ -64,17 +62,7 @@ func NewTakClient(ctx context.Context, config ClientConfig) (*TakClient, error) 
 
 	go client.handleWrite()
 	go client.pinger(ctx)
-
-	c = &client
-
 	return &client, nil
-}
-
-func GetClient() *TakClient {
-	if c == nil {
-		return nil
-	}
-	return c
 }
 
 func (c *TakClient) Close() error {

--- a/pkg/cot/constants.go
+++ b/pkg/cot/constants.go
@@ -1,0 +1,18 @@
+package cot
+
+const (
+    // NotNum sentinel numeric
+    NotNum = 999999
+
+    // TypePing CoT “Type” codes
+    TypePing    = "t-x-c-t"
+    TypePong    = "t-x-c-t-r"
+    TypeOffline = "t-x-d-d"
+    TypeDpSpi   = "b-m-p-s-p-i"
+    TypeTeam    = "a-f-G-U-C"
+
+    // HowDefault CoT “How” modes
+    HowDefault  = "m-g"
+    HowResponse = "h-g-i-g-o"
+    HowEvent    = "h-e"
+)


### PR DESCRIPTION
- Remove package‑level `TakClient` var and `GetClient()` accessor
  - Eliminates hidden shared state for better test isolation
  - Forces explicit client lifecycle management and cleanup
  - Allows multiple independent clients for different endpoints or tests
  - Promotes explicit dependency injection over globals
- Add MakeTeamMarker function
- Introduce typed constants for CoT event types (`TypePing`, `TypePong`, `TypeOffline`, `TypeDpSpi`, `TypeTeam`)
- Introduce constants for CoT “How” modes (`HowDefault`, `HowResponse`, `HowEvent`)
- Refactor `BasicMsg` and all `Make*` functions to use new constants and add Go‑doc comments
- Move `NotNum` and related consts into `pkg/cot/constants.go`