### PR TITLE
feat(client): automatic reconnect with back‑off

### DIFF
--- a/pkg/client/reconnect.go
+++ b/pkg/client/reconnect.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"context"
+	"github.com/rs/zerolog"
+	"math/rand"
+	"net"
+	"time"
+)
+
+func dialWithBackoff(ctx context.Context, addr string,
+	log zerolog.Logger,
+	p ReconnectPolicy) (net.Conn, error) {
+
+	if p.MinDelay == 0 {
+		p.MinDelay = time.Second
+	}
+	if p.MaxDelay == 0 {
+		p.MaxDelay = 30 * time.Second
+	}
+
+	attempt := 0
+	delay := p.MinDelay
+
+	for {
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			if attempt > 0 {
+				log.Info().
+					Int("attempt", attempt).
+					Str("addr", addr).
+					Msg("reconnected")
+			}
+			return conn, nil
+		}
+
+		if !p.Enable ||
+			(p.MaxRetries > 0 && attempt >= p.MaxRetries) {
+			return nil, err
+		}
+
+		// jittered exponential back‑off
+		sleep := delay + time.Duration(rand.Int63n(int64(delay/2)))
+		log.Warn().
+			Err(err).
+			Str("addr", addr).
+			Dur("sleep", sleep).
+			Int("attempt", attempt+1).
+			Msg("dial failed – retrying")
+		select {
+		case <-time.After(sleep):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		if delay *= 2; delay > p.MaxDelay {
+			delay = p.MaxDelay
+		}
+		attempt++
+	}
+}

--- a/pkg/client/reconnect_test.go
+++ b/pkg/client/reconnect_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+    "context"
+    "github.com/rs/zerolog"
+    "io"
+    "net"
+    "testing"
+    "time"
+)
+
+var sink = zerolog.New(io.Discard)
+
+// ---------------------------------------------------------------------------
+//  1. positive path— first two dials fail, third succeeds after we start
+//     listening on the chosen port
+//
+// ---------------------------------------------------------------------------
+func TestDialWithBackoff_SucceedsAfterServerComesUp(t *testing.T) {
+
+    lh, err := net.Listen("tcp", "127.0.0.1:0")
+    if err != nil {
+        t.Fatalf("cannot grab ephemeral port: %v", err)
+    }
+    addr := lh.Addr().String()
+    lh.Close() // nobody is listening now
+
+    pol := ReconnectPolicy{
+        Enable:     true,
+        MinDelay:   10 * time.Millisecond,
+        MaxDelay:   20 * time.Millisecond,
+        MaxRetries: 0, // unlimited
+    }
+
+    ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+    defer cancel()
+
+    done := make(chan struct{})
+    var c net.Conn
+    go func() {
+        var e error
+        c, e = dialWithBackoff(ctx, addr, sink, pol)
+        if e != nil {
+            t.Errorf("dialWithBackoff returned unexpected error: %v", e)
+        }
+        close(done)
+    }()
+
+    time.Sleep(40 * time.Millisecond)
+
+    server, err := net.Listen("tcp", addr)
+    if err != nil {
+        t.Fatalf("failed to start listener: %v", err)
+    }
+    defer server.Close()
+
+    go func() {
+        conn, _ := server.Accept()
+        if conn != nil {
+            _ = conn.Close()
+        }
+    }()
+
+    select {
+    case <-done:
+        if c == nil {
+            t.Fatal("dialWithBackoff returned nil connection")
+        }
+        _ = c.Close()
+    case <-ctx.Done():
+        t.Fatal("dialWithBackoff never succeeded before context deadline")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2) negative path — stop after MaxRetries and surface the final error
+// ---------------------------------------------------------------------------
+func TestDialWithBackoff_StopsAfterMaxRetries(t *testing.T) {
+    pol := ReconnectPolicy{
+        Enable:     true,
+        MinDelay:   5 * time.Millisecond,
+        MaxDelay:   10 * time.Millisecond,
+        MaxRetries: 3, // small so the test is fast
+    }
+    ctx := context.Background()
+
+    _, err := dialWithBackoff(ctx, "127.0.0.1:1", sink, pol) // nobody there
+    if err == nil {
+        t.Fatal("expected error after exhausting retries, got nil")
+    }
+}


### PR DESCRIPTION
Adds opt‑in autoreconnect so TakClient can recover from dropped links without caller intervention.

- Config: new ReconnectPolicy on ClientConfig • Enable, MinDelay, MaxDelay, MaxRetries • Zero values keep prior one‑shot dial behaviour.

- Dial helper: dialWithBackoff • Exponential back‑off with half‑jitter • Context‑aware, nil‑safe logger fallback.

- Runtime wiring • NewTakClient now uses dialWithBackoff. • handleWrite retries on write errors and swaps the Conn when re‑established. • Stop() cancels context before closing channels to avoid races.

- Tests: reconnect_test.go verifies success after late listener start and failure after MaxRetries.